### PR TITLE
Remove settlement

### DIFF
--- a/frontend/src/components/SettlementList.tsx
+++ b/frontend/src/components/SettlementList.tsx
@@ -187,9 +187,9 @@ export function SettlementList({ onSettlementUpdate }: SettlementListProps) {
           <div className="bg-gray-50 rounded-lg p-4">
             <h4 className="font-medium text-gray-900 mb-2">承認済み精算明細</h4>
             <div className="space-y-2">
-              {approvedSettlements.map((settlement) => (
+              {approvedSettlements.map((settlement, index) => (
                 <div key={settlement.id} className="flex justify-between text-sm">
-                  <span>精算 #{settlement.id.split('_')[1]}</span>
+                  <span>精算 {index + 1}</span>
                   <span className="font-medium">¥{settlement.settlementAmount.toLocaleString()}</span>
                 </div>
               ))}
@@ -246,7 +246,7 @@ export function SettlementList({ onSettlementUpdate }: SettlementListProps) {
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
                       <h3 className="text-sm font-medium text-gray-900">
-                        精算 #{settlement.id.split('_')[1]}
+                        精算
                       </h3>
                       {getStatusBadge(settlement.status)}
                     </div>

--- a/frontend/src/components/SettlementList.tsx
+++ b/frontend/src/components/SettlementList.tsx
@@ -251,7 +251,7 @@ export function SettlementList({ onSettlementUpdate }: SettlementListProps) {
                       {getStatusBadge(settlement.status)}
                     </div>
                     
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
                       <div>
                         <span className="text-gray-500">夫の負担額:</span>
                         <span className="ml-2 font-medium text-gray-900">
@@ -262,6 +262,12 @@ export function SettlementList({ onSettlementUpdate }: SettlementListProps) {
                         <span className="text-gray-500">妻の負担額:</span>
                         <span className="ml-2 font-medium text-gray-900">
                           ¥{settlement.wifeAmount.toLocaleString()}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-gray-500">合計金額:</span>
+                        <span className="ml-2 font-medium text-gray-900">
+                          ¥{(settlement.husbandAmount + settlement.wifeAmount).toLocaleString()}
                         </span>
                       </div>
                       <div>


### PR DESCRIPTION
# Overview
- This PR improves the settlement list user experience by removing unnecessary technical IDs and adding total amount display

# Background
- close #3
- close #4

# Details
- **Settlement ID Removal**: Removed technical settlement IDs from cards and final settlement summary for cleaner display
- **Total Amount Display**: Added total amount field (husband amount + wife amount) to settlement cards for complete expense overview
- **UI Layout**: Updated grid layout from 3 columns to 4 columns to accommodate new total amount field
- **Numbering System**: Changed from technical IDs to sequential numbering (精算 1, 精算 2, etc.) in final settlement summary

# Next Steps
- Add verification button next to settlement amount in settlement cards on the settlement list tab, which will display settlement logic in an easy-to-understand format when pressed

# Captures
<img width="1440" alt="スクリーンショット 2025-07-06 23 16 52" src="https://github.com/user-attachments/assets/e16ed4cb-b5ad-4f7c-9449-b86bbf01f836" />