### PR TITLE
fix: Configure development environment OAuth settings to resolve login loop

### DIFF
--- a/backend/src/index-mysql.ts
+++ b/backend/src/index-mysql.ts
@@ -84,10 +84,18 @@ const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NOD
 const frontendUrl = isDevelopment ? 'http://localhost:3000' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com';
 const backendUrl = isDevelopment ? 'http://localhost:3001' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com';
 
+console.log('OAuth Configuration:', {
+  NODE_ENV: process.env.NODE_ENV,
+  isDevelopment,
+  frontendUrl,
+  backendUrl,
+  callbackURL: `${backendUrl}/auth/google/callback`
+});
+
 passport.use(new GoogleStrategy({
   clientID: process.env.GOOGLE_CLIENT_ID!,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-  callbackURL: "http://localhost:3001/auth/google/callback",
+  callbackURL: `${backendUrl}/auth/google/callback`,
 },
 (accessToken, refreshToken, profile, done) => {
   console.log('OAuth callback received for user:', profile.displayName);

--- a/backend/src/index-mysql.ts
+++ b/backend/src/index-mysql.ts
@@ -36,8 +36,17 @@ const PORT = process.env.PORT || 3001;
 
 // ミドルウェア
 app.use(helmet());
+// 開発環境かどうかを判定
+const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
+const frontendUrl = process.env.FRONTEND_URL || (isDevelopment ? 'http://localhost:3000' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com');
+const backendUrl = process.env.BACKEND_URL || (isDevelopment ? 'http://localhost:3001' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com');
+
+const corsOrigins = isDevelopment 
+  ? ['http://localhost:3000', 'http://localhost:5173']
+  : [frontendUrl];
+
 app.use(cors({
-  origin: ['http://localhost:3000', 'http://localhost:5173', 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com'],
+  origin: corsOrigins,
   credentials: true
 }));
 app.use(express.json());
@@ -78,11 +87,6 @@ passport.serializeUser((user: any, done) => {
 passport.deserializeUser((user: any, done) => {
   done(null, user);
 });
-
-// 開発環境かどうかを判定
-const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
-const frontendUrl = isDevelopment ? 'http://localhost:3000' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com';
-const backendUrl = isDevelopment ? 'http://localhost:3001' : 'http://splitmate-alb-906594043.ap-northeast-1.elb.amazonaws.com';
 
 console.log('OAuth Configuration:', {
   NODE_ENV: process.env.NODE_ENV,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,7 +46,7 @@ services:
       - ./package.json:/app/package.json
       - ./package-lock.json:/app/package-lock.json
     env_file:
-      - ./backend/.env
+      - ./backend/.env.local
     networks:
       - splitmate-network-dev
 
@@ -60,7 +60,7 @@ services:
     environment:
       VITE_API_URL: http://localhost:3001
     ports:
-      - "3000:3000"
+      - "5173:5173"
     depends_on:
       - backend
     volumes:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN npm install
 COPY . .
 
 # Expose port
-EXPOSE 3000
+EXPOSE 5173
 
 # Start the development server
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"] 
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"] 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -281,6 +281,10 @@ resource "aws_ecs_task_definition" "backend" {
           value = "http://${aws_lb.main.dns_name}"
         },
         {
+          name  = "BACKEND_URL"
+          value = "http://${aws_lb.main.dns_name}"
+        },
+        {
           name  = "GOOGLE_CLIENT_ID"
           value = var.google_client_id
         },


### PR DESCRIPTION
- Switch development environment to use .env.local instead of production .env file
- Update frontend port from 3000 to 5173 to align with existing .env.local configuration
- Resolve OAuth login loop issue where users were redirected to production during development testing