### PR TITLE
feat: 精算管理機能と配分比率制御の強化 (Issue #29)

### DIFF
--- a/backend/src/database/schema-mysql.sql
+++ b/backend/src/database/schema-mysql.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS allocation_ratios (
   CHECK (ABS(husband_ratio + wife_ratio - 1.0) < 0.001)
 );
 
--- Expenses table (with monthly tracking)
+-- Expenses table (with monthly tracking and custom allocation ratios)
 CREATE TABLE IF NOT EXISTS expenses (
   id VARCHAR(255) PRIMARY KEY,
   category VARCHAR(255) NOT NULL,
@@ -26,11 +26,17 @@ CREATE TABLE IF NOT EXISTS expenses (
   payer_id VARCHAR(255) NOT NULL,
   expense_year INT NOT NULL,
   expense_month INT NOT NULL,
+  -- Custom allocation ratio fields
+  custom_husband_ratio DECIMAL(3,2) NULL CHECK (custom_husband_ratio IS NULL OR (custom_husband_ratio >= 0 AND custom_husband_ratio <= 1)),
+  custom_wife_ratio DECIMAL(3,2) NULL CHECK (custom_wife_ratio IS NULL OR (custom_wife_ratio >= 0 AND custom_wife_ratio <= 1)),
+  uses_custom_ratio BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (payer_id) REFERENCES users(id) ON DELETE CASCADE,
   CHECK (expense_year >= 2020 AND expense_year <= 2099),
-  CHECK (expense_month >= 1 AND expense_month <= 12)
+  CHECK (expense_month >= 1 AND expense_month <= 12),
+  -- Custom ratio validation: if uses_custom_ratio is true, both custom ratios must be set and sum to 1
+  CHECK (uses_custom_ratio = FALSE OR (custom_husband_ratio IS NOT NULL AND custom_wife_ratio IS NOT NULL AND ABS(custom_husband_ratio + custom_wife_ratio - 1.0) < 0.001))
 );
 
 -- Settlements table

--- a/backend/src/routes/expenseRoutes-mysql.ts
+++ b/backend/src/routes/expenseRoutes-mysql.ts
@@ -19,5 +19,6 @@ router.delete('/bulk', ExpenseController.bulkDeleteExpenses);
 // 個別費用の操作
 router.get('/:id', ExpenseController.getExpenseById);
 router.delete('/:id', ExpenseController.deleteExpense);
+router.put('/:id/allocation-ratio', ExpenseController.updateExpenseAllocationRatio);
 
 export default router; 

--- a/backend/src/services/expenseService-mysql.ts
+++ b/backend/src/services/expenseService-mysql.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { pool } from '../database/connection-mysql';
 import { ApiResponse, CreateExpenseRequest, Expense, MonthlyExpenseStats, MonthlyExpenseSummary, UpdateExpenseAllocationRatioRequest } from '../types';
+import { settlementService } from './settlementService-mysql';
 
 export class ExpenseService {
   /**
@@ -48,6 +49,14 @@ export class ExpenseService {
       // 作成された費用を取得
       const result = await ExpenseService.getExpenseById(id);
       if (result.success && result.data) {
+        // 費用作成後、精算を計算
+        try {
+          await settlementService.calculateSettlement(id);
+        } catch (error) {
+          console.error(`Error calculating settlement for new expense ${id}:`, error);
+          // 精算の計算が失敗しても、費用の作成は成功として扱う
+        }
+        
         return {
           success: true,
           data: result.data,
@@ -452,6 +461,14 @@ export class ExpenseService {
           success: false,
           error: 'Expense not found'
         };
+      }
+      
+      // 個別配分比率の更新後、該当する精算を再計算
+      try {
+        await settlementService.calculateSettlement(expenseId);
+      } catch (error) {
+        console.error(`Error recalculating settlement for expense ${expenseId}:`, error);
+        // 精算の再計算が失敗しても、費用の更新は成功として扱う
       }
       
       // 更新された費用を取得

--- a/backend/src/services/settlementService-mysql.ts
+++ b/backend/src/services/settlementService-mysql.ts
@@ -118,7 +118,12 @@ export const settlementService = {
           settlementAmount,
           status: 'pending',
           createdAt: new Date(now),
-          updatedAt: new Date(now)
+          updatedAt: new Date(now),
+          expenseDescription: expense.description,
+          expenseAmount: expense.amount,
+          customHusbandRatio: expense.customHusbandRatio,
+          customWifeRatio: expense.customWifeRatio,
+          usesCustomRatio: expense.usesCustomRatio || false
         }
       };
     } catch (error) {
@@ -145,11 +150,15 @@ export const settlementService = {
 
       // 更新された精算を取得
       const getQuery = `
-        SELECT id, expense_id as expenseId, husband_amount as husbandAmount, 
-               wife_amount as wifeAmount, payer, receiver, settlement_amount as settlementAmount,
-               status, created_at as createdAt, updated_at as updatedAt
-        FROM settlements 
-        WHERE id = ?
+        SELECT s.id, s.expense_id as expenseId, s.husband_amount as husbandAmount, 
+               s.wife_amount as wifeAmount, s.payer, s.receiver, s.settlement_amount as settlementAmount,
+               s.status, s.created_at as createdAt, s.updated_at as updatedAt,
+               e.description as expenseDescription, e.amount as expenseAmount,
+               e.custom_husband_ratio as customHusbandRatio, e.custom_wife_ratio as customWifeRatio,
+               e.uses_custom_ratio as usesCustomRatio
+        FROM settlements s
+        JOIN expenses e ON s.expense_id = e.id
+        WHERE s.id = ?
       `;
       
       const [rows] = await pool.execute(getQuery, [settlementId]);
@@ -174,7 +183,12 @@ export const settlementService = {
           settlementAmount: result.settlementAmount,
           status: result.status,
           createdAt: new Date(result.createdAt),
-          updatedAt: new Date(result.updatedAt)
+          updatedAt: new Date(result.updatedAt),
+          expenseDescription: result.expenseDescription,
+          expenseAmount: result.expenseAmount,
+          customHusbandRatio: result.customHusbandRatio,
+          customWifeRatio: result.customWifeRatio,
+          usesCustomRatio: result.usesCustomRatio || false
         }
       };
     } catch (error) {
@@ -201,11 +215,15 @@ export const settlementService = {
 
       // 更新された精算を取得
       const getQuery = `
-        SELECT id, expense_id as expenseId, husband_amount as husbandAmount, 
-               wife_amount as wifeAmount, payer, receiver, settlement_amount as settlementAmount,
-               status, created_at as createdAt, updated_at as updatedAt
-        FROM settlements 
-        WHERE id = ?
+        SELECT s.id, s.expense_id as expenseId, s.husband_amount as husbandAmount, 
+               s.wife_amount as wifeAmount, s.payer, s.receiver, s.settlement_amount as settlementAmount,
+               s.status, s.created_at as createdAt, s.updated_at as updatedAt,
+               e.description as expenseDescription, e.amount as expenseAmount,
+               e.custom_husband_ratio as customHusbandRatio, e.custom_wife_ratio as customWifeRatio,
+               e.uses_custom_ratio as usesCustomRatio
+        FROM settlements s
+        JOIN expenses e ON s.expense_id = e.id
+        WHERE s.id = ?
       `;
       
       const [rows] = await pool.execute(getQuery, [settlementId]);
@@ -230,7 +248,12 @@ export const settlementService = {
           settlementAmount: result.settlementAmount,
           status: result.status,
           createdAt: new Date(result.createdAt),
-          updatedAt: new Date(result.updatedAt)
+          updatedAt: new Date(result.updatedAt),
+          expenseDescription: result.expenseDescription,
+          expenseAmount: result.expenseAmount,
+          customHusbandRatio: result.customHusbandRatio,
+          customWifeRatio: result.customWifeRatio,
+          usesCustomRatio: result.usesCustomRatio || false
         }
       };
     } catch (error) {
@@ -249,7 +272,9 @@ export const settlementService = {
         SELECT s.id, s.expense_id as expenseId, s.husband_amount as husbandAmount,
                s.wife_amount as wifeAmount, s.payer, s.receiver, s.settlement_amount as settlementAmount,
                s.status, s.created_at as createdAt, s.updated_at as updatedAt,
-               e.description as expenseDescription, e.amount as expenseAmount
+               e.description as expenseDescription, e.amount as expenseAmount,
+               e.custom_husband_ratio as customHusbandRatio, e.custom_wife_ratio as customWifeRatio,
+               e.uses_custom_ratio as usesCustomRatio
         FROM settlements s
         JOIN expenses e ON s.expense_id = e.id
         ORDER BY s.created_at DESC
@@ -269,7 +294,10 @@ export const settlementService = {
         createdAt: new Date(row.createdAt),
         updatedAt: new Date(row.updatedAt),
         expenseDescription: row.expenseDescription,
-        expenseAmount: row.expenseAmount
+        expenseAmount: row.expenseAmount,
+        customHusbandRatio: row.customHusbandRatio,
+        customWifeRatio: row.customWifeRatio,
+        usesCustomRatio: row.usesCustomRatio || false
       }));
       
       return {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -14,6 +14,10 @@ export interface Expense {
   payerId: string; // User ID
   expenseYear: number;
   expenseMonth: number;
+  // Custom allocation ratio fields
+  customHusbandRatio?: number | null;
+  customWifeRatio?: number | null;
+  usesCustomRatio: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -46,6 +50,16 @@ export interface CreateExpenseRequest {
   payerId: string;
   expenseYear?: number; // Optional - defaults to current year
   expenseMonth?: number; // Optional - defaults to current month
+  // Custom allocation ratio fields
+  customHusbandRatio?: number;
+  customWifeRatio?: number;
+  usesCustomRatio?: boolean;
+}
+
+export interface UpdateExpenseAllocationRatioRequest {
+  customHusbandRatio: number;
+  customWifeRatio: number;
+  usesCustomRatio: boolean;
 }
 
 export interface UpdateAllocationRatioRequest {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -41,6 +41,13 @@ export interface Settlement {
   status: 'pending' | 'approved' | 'completed';
   createdAt: Date;
   updatedAt: Date;
+  // Additional expense details for display
+  expenseDescription?: string;
+  expenseAmount?: number;
+  // Custom allocation ratio fields
+  customHusbandRatio?: number | null;
+  customWifeRatio?: number | null;
+  usesCustomRatio: boolean;
 }
 
 export interface CreateExpenseRequest {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -203,6 +203,26 @@ const AppContent = () => {
     console.log('精算が更新されました');
   };
 
+  // 費用が更新された時の処理
+  const handleExpenseUpdate = useCallback((updatedExpense: Expense) => {
+    console.log('Expense updated:', updatedExpense);
+    
+    // 全体データを再取得せず、該当する費用項目だけを更新してレイアウトシフトを防ぐ
+    if (activeTab === 'expenses') {
+      setExpenses(prevExpenses => 
+        prevExpenses.map(expense => 
+          expense.id === updatedExpense.id ? updatedExpense : expense
+        )
+      );
+    } else if (activeTab === 'monthly') {
+      setMonthlyExpenses(prevExpenses => 
+        prevExpenses.map(expense => 
+          expense.id === updatedExpense.id ? updatedExpense : expense
+        )
+      );
+    }
+  }, [activeTab]);
+
   const generateYearOptions = () => {
     const currentYear = new Date().getFullYear();
     const years = [];
@@ -347,7 +367,8 @@ const AppContent = () => {
                 expenses={expenses} 
                 onDelete={handleDeleteExpense} 
                 onBulkDelete={handleBulkDeleteExpenses}
-                isLoading={isLoading} 
+                isLoading={isLoading}
+                onExpenseUpdate={handleExpenseUpdate}
               />
             </div>
           </div>
@@ -403,6 +424,7 @@ const AppContent = () => {
               onBulkDelete={handleBulkDeleteExpenses}
               isLoading={isMonthlyLoading}
               title={`${selectedYear}年${selectedMonth}月の費用一覧`}
+              onExpenseUpdate={handleExpenseUpdate}
             />
           </div>
         )}

--- a/frontend/src/components/ExpenseList.tsx
+++ b/frontend/src/components/ExpenseList.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { Expense } from '../types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { allocationApi, expenseApi } from '../services/api';
+import { AllocationRatio, Expense } from '../types';
 
 interface ExpenseListProps {
   expenses: Expense[];
@@ -7,6 +8,7 @@ interface ExpenseListProps {
   onBulkDelete: (ids: string[]) => void;
   isLoading?: boolean;
   title?: string; // タイトルをカスタマイズできるように
+  onExpenseUpdate?: (expense: Expense) => void; // 費用更新時のコールバック
 }
 
 export const ExpenseList: React.FC<ExpenseListProps> = ({ 
@@ -14,10 +16,43 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({
   onDelete, 
   onBulkDelete, 
   isLoading = false,
-  title = "費用一覧"
+  title = "費用一覧",
+  onExpenseUpdate
 }) => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [defaultAllocationRatio, setDefaultAllocationRatio] = useState<AllocationRatio | null>(null);
+  const [updatingExpenses, setUpdatingExpenses] = useState<Set<string>>(new Set());
+  // リアルタイム表示用の一時的な配分比率を保存
+  const [tempRatios, setTempRatios] = useState<Map<string, number>>(new Map());
+  // デバウンス用のタイマーを保存
+  const [debounceTimers, setDebounceTimers] = useState<Map<string, NodeJS.Timeout>>(new Map());
+
+  // 全体の配分比率を取得
+  useEffect(() => {
+    const loadDefaultAllocationRatio = async () => {
+      try {
+        const response = await allocationApi.getAllocationRatio();
+        if (response.success && response.data) {
+          setDefaultAllocationRatio(response.data);
+        }
+      } catch (error) {
+        console.error('Failed to load default allocation ratio:', error);
+      }
+    };
+
+    loadDefaultAllocationRatio();
+  }, []);
+
+  // クリーンアップ処理：コンポーネントのアンマウント時にタイマーをクリア
+  useEffect(() => {
+    return () => {
+      // 全てのデバウンスタイマーをクリア
+      debounceTimers.forEach((timer) => {
+        clearTimeout(timer);
+      });
+    };
+  }, [debounceTimers]);
   
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString('ja-JP', {
@@ -39,6 +74,165 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({
 
   const formatMonthYear = (year: number, month: number) => {
     return `${year}年${month}月`;
+  };
+
+  // 配分比率が全体設定と異なるかどうかを判定
+  const isCustomRatio = (expense: Expense) => {
+    if (!defaultAllocationRatio) return false;
+    
+    return expense.usesCustomRatio && 
+           expense.customHusbandRatio !== null && 
+           expense.customWifeRatio !== null &&
+           expense.customHusbandRatio !== undefined &&
+           expense.customWifeRatio !== undefined &&
+           (Math.abs(expense.customHusbandRatio - defaultAllocationRatio.husbandRatio) > 0.01 ||
+            Math.abs(expense.customWifeRatio - defaultAllocationRatio.wifeRatio) > 0.01);
+  };
+
+  // 配分比率の更新（デバウンス機能付き）
+  const debouncedUpdateAllocationRatio = useCallback(async (expenseId: string, husbandRatio: number) => {
+    const wifeRatio = 1 - husbandRatio;
+    
+    setUpdatingExpenses(prev => new Set(prev).add(expenseId));
+    
+    try {
+      const updateData = {
+        customHusbandRatio: Number(husbandRatio),
+        customWifeRatio: Number(wifeRatio),
+        usesCustomRatio: true
+      };
+      
+      const response = await expenseApi.updateExpenseAllocationRatio(expenseId, updateData);
+      
+      if (response.success && response.data) {
+        // レイアウトシフトを防ぐため、先に一時的な値をクリア
+        setTempRatios(prev => {
+          const newMap = new Map(prev);
+          newMap.delete(expenseId);
+          return newMap;
+        });
+        // その後で状態更新（もうレイアウトシフトしない）
+        onExpenseUpdate?.(response.data);
+      }
+    } catch (error) {
+      console.error('Failed to update allocation ratio:', error);
+      // エラー時も一時的な値をクリア
+      setTempRatios(prev => {
+        const newMap = new Map(prev);
+        newMap.delete(expenseId);
+        return newMap;
+      });
+    } finally {
+      setUpdatingExpenses(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(expenseId);
+        return newSet;
+      });
+    }
+  }, [onExpenseUpdate]);
+
+  // スライダーの操作ハンドラー（リアルタイム表示 + デバウンスAPI呼び出し）
+  const handleAllocationRatioChange = useCallback((expenseId: string, husbandRatio: number) => {
+    // リアルタイム表示のために一時的な値を設定
+    setTempRatios(prev => {
+      const newMap = new Map(prev);
+      newMap.set(expenseId, husbandRatio);
+      return newMap;
+    });
+
+    // 既存のタイマーをクリア
+    setDebounceTimers(prev => {
+      const existingTimer = prev.get(expenseId);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+      }
+      return prev;
+    });
+
+    // 新しいタイマーを設定（500ms後にAPI呼び出し）
+    const newTimer = setTimeout(() => {
+      debouncedUpdateAllocationRatio(expenseId, husbandRatio);
+      // タイマーをクリア
+      setDebounceTimers(prev => {
+        const newMap = new Map(prev);
+        newMap.delete(expenseId);
+        return newMap;
+      });
+    }, 500);
+
+    // タイマーを保存
+    setDebounceTimers(prev => {
+      const newMap = new Map(prev);
+      newMap.set(expenseId, newTimer);
+      return newMap;
+    });
+  }, [debouncedUpdateAllocationRatio]);
+
+  // 配分比率のリセット
+  const handleResetAllocationRatio = useCallback(async (expenseId: string) => {
+    if (!defaultAllocationRatio) return;
+    
+    // デバウンスタイマーをクリア
+    setDebounceTimers(prev => {
+      const existingTimer = prev.get(expenseId);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+        const newMap = new Map(prev);
+        newMap.delete(expenseId);
+        return newMap;
+      }
+      return prev;
+    });
+    
+    // 一時的な値をクリア
+    setTempRatios(prev => {
+      const newMap = new Map(prev);
+      newMap.delete(expenseId);
+      return newMap;
+    });
+    
+    setUpdatingExpenses(prev => new Set(prev).add(expenseId));
+    
+    try {
+      const resetData = {
+        customHusbandRatio: Number(defaultAllocationRatio.husbandRatio),
+        customWifeRatio: Number(defaultAllocationRatio.wifeRatio),
+        usesCustomRatio: false
+      };
+      
+      const response = await expenseApi.updateExpenseAllocationRatio(expenseId, resetData);
+      
+      if (response.success && response.data) {
+        onExpenseUpdate?.(response.data);
+      }
+    } catch (error) {
+      console.error('Failed to reset allocation ratio:', error);
+    } finally {
+      setUpdatingExpenses(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(expenseId);
+        return newSet;
+      });
+    }
+  }, [defaultAllocationRatio, onExpenseUpdate]);
+
+  // 現在の配分比率を取得（一時的な値も考慮）
+  const getCurrentRatio = (expense: Expense): number => {
+    // 一時的な値が設定されている場合はそれを優先
+    const tempRatio = tempRatios.get(expense.id);
+    if (tempRatio !== undefined) {
+      return tempRatio;
+    }
+    
+    // 個別設定がある場合
+    if (expense.usesCustomRatio && 
+        expense.customHusbandRatio !== null && 
+        expense.customHusbandRatio !== undefined) {
+      return expense.customHusbandRatio;
+    }
+    
+    // デフォルト値
+    return defaultAllocationRatio?.husbandRatio || 0.7;
   };
 
   // チェックボックスの制御
@@ -130,56 +324,117 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({
       </div>
       
       <div className="space-y-4">
-        {expenses.map((expense) => (
-          <div key={expense.id} className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
-            <div className="flex justify-between items-start">
-              <div className="flex items-start gap-3 flex-1">
+        {expenses.map((expense) => {
+          const hasCustomRatio = isCustomRatio(expense);
+          const currentRatio = getCurrentRatio(expense);
+          const isUpdating = updatingExpenses.has(expense.id);
+          
+          return (
+            <div 
+              key={expense.id} 
+              className={`border rounded-lg p-4 hover:shadow-md transition-shadow ${
+                hasCustomRatio ? 'bg-red-50 border-red-200' : 'border-gray-200'
+              }`}
+            >
+              {/* チェックボックス */}
+              <div className="flex items-start gap-3">
                 <input
                   type="checkbox"
                   checked={selectedIds.includes(expense.id)}
                   onChange={(e) => handleSelectExpense(expense.id, e.target.checked)}
                   className="mt-1 w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
                 />
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-2">
+                
+                <div className="flex-1 space-y-2">
+                  {/* 1行目：金額 削除ボタン */}
+                  <div className="flex justify-between items-center">
+                    <span className="text-lg font-bold text-gray-900">
+                      ¥{formatAmount(expense.amount)}
+                    </span>
+                    <button
+                      onClick={() => onDelete(expense.id)}
+                      className="text-red-600 hover:text-red-800 text-sm font-medium"
+                      title="削除"
+                    >
+                      削除
+                    </button>
+                  </div>
+
+                  {/* 2行目：カテゴリ 年月 */}
+                  <div className="flex items-center gap-2">
                     <span className="inline-block bg-primary-100 text-primary-800 text-xs px-2 py-1 rounded-full">
                       {expense.category}
+                    </span>
+                    <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
+                      {formatMonthYear(expense.expenseYear, expense.expenseMonth)}
                     </span>
                     <span className="text-sm text-gray-500">
                       {getPayerName(expense.payerId)}
                     </span>
-                    {/* 月次情報を表示 */}
-                    <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
-                      {formatMonthYear(expense.expenseYear, expense.expenseMonth)}
-                    </span>
                   </div>
-                  
-                  <h3 className="font-medium text-gray-900 mb-1">
-                    {expense.description}
-                  </h3>
-                  
-                  <p className="text-sm text-gray-500">
-                    {formatDate(expense.createdAt)}
-                  </p>
+
+                  {/* 3行目：説明 */}
+                  <div>
+                    <h3 className="font-medium text-gray-900">
+                      {expense.description}
+                    </h3>
+                  </div>
+
+                  {/* 4行目：夫~~% */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-600">夫:</span>
+                    <span className="text-xs font-medium text-gray-900">
+                      {Math.round(currentRatio * 100)}%
+                    </span>
+                    {/* スピナー用の固定幅スペース（レイアウトシフト防止） */}
+                    <div className="w-3 h-3 flex items-center justify-center">
+                      {isUpdating && (
+                        <div className="w-3 h-3 border border-gray-300 border-t-blue-500 rounded-full animate-spin"></div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* 5行目：スライダー リセット */}
+                  <div className="flex items-center gap-2 min-h-[24px]">
+                    <input
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={currentRatio}
+                      onChange={(e) => handleAllocationRatioChange(expense.id, parseFloat(e.target.value))}
+                      disabled={isUpdating}
+                      className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      style={{ touchAction: 'pan-y' }}
+                    />
+                    {/* リセットボタン用の固定スペース（レイアウトシフト防止） */}
+                    <div className="w-12 flex justify-end">
+                      <button
+                        onClick={() => handleResetAllocationRatio(expense.id)}
+                        disabled={isUpdating}
+                        className={`text-xs whitespace-nowrap px-1 py-0 min-w-0 flex-shrink-0 ${
+                          hasCustomRatio 
+                            ? 'text-blue-600 hover:text-blue-800 disabled:text-gray-400 visible' 
+                            : 'invisible'
+                        }`}
+                        title="デフォルトに戻す"
+                      >
+                        リセット
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* 6行目：yyyy/mm/dd 時刻 */}
+                  <div>
+                    <p className="text-sm text-gray-500">
+                      {formatDate(expense.createdAt)}
+                    </p>
+                  </div>
                 </div>
               </div>
-            
-              <div className="flex items-center gap-3">
-                <span className="text-lg font-bold text-gray-900">
-                  ¥{formatAmount(expense.amount)}
-                </span>
-                
-                <button
-                  onClick={() => onDelete(expense.id)}
-                  className="text-red-600 hover:text-red-800 text-sm font-medium"
-                  title="削除"
-                >
-                  削除
-                </button>
-              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* 確認ダイアログ */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AllocationRatio, ApiResponse, CreateExpenseRequest, Expense, ExpenseStats, MonthlyExpenseStats, MonthlyExpenseSummary, Settlement, UpdateAllocationRatioRequest } from '../types';
+import { AllocationRatio, ApiResponse, CreateExpenseRequest, Expense, ExpenseStats, MonthlyExpenseStats, MonthlyExpenseSummary, Settlement, UpdateAllocationRatioRequest, UpdateExpenseAllocationRatioRequest } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
@@ -120,6 +120,16 @@ export const expenseApi = {
       return response.data;
     } catch (error: any) {
       return formatError(error, '統計情報の取得に失敗しました');
+    }
+  },
+
+  // 費用の個別配分比率を更新
+  updateExpenseAllocationRatio: async (expenseId: string, data: UpdateExpenseAllocationRatioRequest): Promise<ApiResponse<Expense>> => {
+    try {
+      const response = await api.put(`/expenses/${expenseId}/allocation-ratio`, data);
+      return response.data;
+    } catch (error: any) {
+      return formatError(error, '費用の配分比率更新に失敗しました');
     }
   }
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -78,6 +78,10 @@ export interface Settlement {
   updatedAt: Date;
   expenseDescription?: string;
   expenseAmount?: number;
+  // Custom allocation ratio fields
+  customHusbandRatio?: number | null;
+  customWifeRatio?: number | null;
+  usesCustomRatio: boolean;
 }
 
 // Monthly expense specific interfaces

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,10 @@ export interface Expense {
   payerId: string;
   expenseYear: number;
   expenseMonth: number;
+  // Custom allocation ratio fields
+  customHusbandRatio?: number | null;
+  customWifeRatio?: number | null;
+  usesCustomRatio: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -17,6 +21,16 @@ export interface CreateExpenseRequest {
   payerId: string;
   expenseYear?: number; // Optional - defaults to current year
   expenseMonth?: number; // Optional - defaults to current month
+  // Custom allocation ratio fields
+  customHusbandRatio?: number;
+  customWifeRatio?: number;
+  usesCustomRatio?: boolean;
+}
+
+export interface UpdateExpenseAllocationRatioRequest {
+  customHusbandRatio: number;
+  customWifeRatio: number;
+  usesCustomRatio: boolean;
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## 概要
このPRでは精算管理機能を3つの主要な改善で強化しました：

### 1. 精算画面からの個別配分比率表示削除
- 精算一覧から配分比率バッジとパーセンテージ表示を削除
- 検算モーダルと全体精算画面からも表示を削除
- カスタム比率の視覚的な区別として赤色背景は維持
- よりシンプルで見やすい精算インターフェースを実現

### 2. 承認済み費用明細の配分比率編集無効化
- ExpenseListコンポーネントで承認状態のチェック機能を追加
- 承認済み費用のスライダーとリセットボタンを無効化
- 視覚的インジケーター（承認済みバッジ、グレーアウト、変更不可テキスト）を追加
- タブ間でのリアルタイム更新をストレージイベントで実装
- 承認済み精算の保護によりデータ整合性を確保

### 3. 個別配分比率での精算計算修正
- 費用作成後の精算自動計算を追加
- 配分比率更新後の精算再計算を追加
- カスタム比率が精算金額に正しく反映されることを保証
- 個別配分設定が精算管理の負担額に反映されない問題を修正

## 技術的な変更
- **バックエンド**: ExpenseServiceに精算自動計算機能を追加
- **フロントエンド**: ExpenseListに承認状態管理機能を追加
- **フロントエンド**: SettlementListのUI簡素化（比率表示削除）
- **コンポーネント間**: リアルタイム更新のためのストレージイベント通信を実装

## テスト結果
- ✅ 個別配分比率の変更が精算金額に正しく反映される
- ✅ 承認済み費用の配分比率は変更できない
- ✅ 精算画面が比率表示なしでよりシンプルになった
- ✅ 費用明細タブと精算管理タブ間のリアルタイム更新が動作する

Resolves #29