### PR TITLE
精算方向表示の修正 (Issue #39)

### DIFF
--- a/frontend/src/components/SettlementList.tsx
+++ b/frontend/src/components/SettlementList.tsx
@@ -159,18 +159,18 @@ function FinalSettlementVerificationModal({ settlements, isOpen, onClose }: Fina
   if (!isOpen) return null;
 
   const getCalculationDetails = () => {
-    let husbandShouldReceive = 0; // 夫が受け取るべき金額（妻からの支払い）
-    let wifeShouldReceive = 0;    // 妻が受け取るべき金額（夫からの支払い）
+    let husbandShouldPay = 0;  // 夫が支払うべき金額
+    let wifeShouldPay = 0;     // 妻が支払うべき金額
     
     const details = settlements.map((settlement) => {
       const receiverAmount = settlement.receiver === 'husband' ? settlement.settlementAmount : -settlement.settlementAmount;
       
       if (settlement.receiver === 'husband') {
-        // receiver = husband means 妻が夫に支払うべき
-        husbandShouldReceive += settlement.settlementAmount;
+        // receiver = husband means 夫が支払うべき
+        husbandShouldPay += settlement.settlementAmount;
       } else {
-        // receiver = wife means 夫が妻に支払うべき
-        wifeShouldReceive += settlement.settlementAmount;
+        // receiver = wife means 妻が支払うべき
+        wifeShouldPay += settlement.settlementAmount;
       }
       
       return {
@@ -186,20 +186,20 @@ function FinalSettlementVerificationModal({ settlements, isOpen, onClose }: Fina
       };
     });
     
-    const finalDirection = husbandShouldReceive > wifeShouldReceive ? {
-      from: '妻',
-      to: '夫', 
-      amount: husbandShouldReceive - wifeShouldReceive
-    } : wifeShouldReceive > husbandShouldReceive ? {
+    const finalDirection = husbandShouldPay > wifeShouldPay ? {
       from: '夫',
-      to: '妻',
-      amount: wifeShouldReceive - husbandShouldReceive
+      to: '妻', 
+      amount: husbandShouldPay - wifeShouldPay
+    } : wifeShouldPay > husbandShouldPay ? {
+      from: '妻',
+      to: '夫',
+      amount: wifeShouldPay - husbandShouldPay
     } : null;
     
-    return { details, finalDirection, husbandShouldReceive, wifeShouldReceive };
+    return { details, finalDirection, husbandShouldPay, wifeShouldPay };
   };
 
-  const { details, finalDirection, husbandShouldReceive, wifeShouldReceive } = getCalculationDetails();
+  const { details, finalDirection, husbandShouldPay, wifeShouldPay } = getCalculationDetails();
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -257,12 +257,12 @@ function FinalSettlementVerificationModal({ settlements, isOpen, onClose }: Fina
             <h4 className="font-medium text-blue-900 mb-3">合計計算</h4>
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
-                <span className="text-blue-700 font-medium">夫の受け取り合計:</span>
-                <span className="ml-2 text-blue-900 font-bold">¥{husbandShouldReceive.toLocaleString()}</span>
+                <span className="text-blue-700 font-medium">夫の支払い合計:</span>
+                <span className="ml-2 text-blue-900 font-bold">¥{husbandShouldPay.toLocaleString()}</span>
               </div>
               <div>
-                <span className="text-blue-700 font-medium">妻の受け取り合計:</span>
-                <span className="ml-2 text-blue-900 font-bold">¥{wifeShouldReceive.toLocaleString()}</span>
+                <span className="text-blue-700 font-medium">妻の支払い合計:</span>
+                <span className="ml-2 text-blue-900 font-bold">¥{wifeShouldPay.toLocaleString()}</span>
               </div>
             </div>
           </div>
@@ -405,30 +405,30 @@ export function SettlementList({ onSettlementUpdate }: SettlementListProps) {
   const getSettlementDirection = () => {
     const approvedSettlements = getApprovedSettlements();
     
-    let husbandShouldReceive = 0; // 夫が受け取るべき金額（妻からの支払い）
-    let wifeShouldReceive = 0;    // 妻が受け取るべき金額（夫からの支払い）
+    let husbandShouldPay = 0;  // 夫が支払うべき金額
+    let wifeShouldPay = 0;     // 妻が支払うべき金額
     
     approvedSettlements.forEach(settlement => {
       if (settlement.receiver === 'husband') {
-        // receiver = husband means 妻が夫に支払うべき
-        husbandShouldReceive += settlement.settlementAmount;
+        // receiver = husband means 夫が支払うべき
+        husbandShouldPay += settlement.settlementAmount;
       } else {
-        // receiver = wife means 夫が妻に支払うべき
-        wifeShouldReceive += settlement.settlementAmount;
+        // receiver = wife means 妻が支払うべき
+        wifeShouldPay += settlement.settlementAmount;
       }
     });
     
-    if (husbandShouldReceive > wifeShouldReceive) {
-      return {
-        from: '妻',
-        to: '夫',
-        amount: husbandShouldReceive - wifeShouldReceive
-      };
-    } else if (wifeShouldReceive > husbandShouldReceive) {
+    if (husbandShouldPay > wifeShouldPay) {
       return {
         from: '夫',
         to: '妻',
-        amount: wifeShouldReceive - husbandShouldReceive
+        amount: husbandShouldPay - wifeShouldPay
+      };
+    } else if (wifeShouldPay > husbandShouldPay) {
+      return {
+        from: '妻',
+        to: '夫',
+        amount: wifeShouldPay - husbandShouldPay
       };
     } else {
       return {


### PR DESCRIPTION
## 概要
Issue #39で報告された精算方向表示の問題を修正しました。

## 修正内容

### 🐛 問題
- 精算確定完了時の支払い方向が逆に表示されていた
- 個別精算明細の支払い方向（矢印）が逆になっていた
- 精算ロジック検算の計算結果が間違っていた

### �� 修正
1. **精算方向計算ロジックの修正**
   - `getSettlementDirection` 関数の計算ロジックを正しく修正
   - 変数名を明確化: `husbandShouldPay`, `wifeShouldPay`

2. **個別精算明細の表示修正**
   - 支払い方向を `receiver → payer` に修正（実際の支払い方向）

3. **精算ロジック検算モーダルの修正**
   - `FinalSettlementVerificationModal` の計算ロジックを修正
   - 表示ラベルを「支払い合計」に変更

### �� 修正例
**配分比率**: 夫70%, 妻30%の場合
- 夫の費用¥2,000 → 妻が夫に¥600支払う
- 妻の費用¥1,000 → 夫が妻に¥700支払う
- **差し引き**: 夫から妻に¥100支払う ✅

**修正前**: 「妻から夫に¥100を支払ってください」❌
**修正後**: 「夫から妻に¥100を支払ってください」✅

## テスト
- [x] 開発環境で動作確認済み
- [x] 精算方向の計算が正しく動作することを確認
- [x] UI表示が正しく修正されていることを確認

## 関連Issue
Fixes #39