### PR TITLE
カテゴリ機能の完全削除 (Issue #27)

### DIFF
--- a/backend/src/controllers/expenseController-mysql.ts
+++ b/backend/src/controllers/expenseController-mysql.ts
@@ -4,7 +4,6 @@ import { ExpenseService } from '../services/expenseService-mysql';
 
 // バリデーションスキーマ
 const createExpenseSchema = z.object({
-  category: z.string().min(1, 'Category is required'),
   description: z.string().min(1, 'Description is required'),
   amount: z.number().positive('Amount must be positive'),
   payerId: z.string().min(1, 'Payer ID is required'),

--- a/backend/src/database/schema-mysql.sql
+++ b/backend/src/database/schema-mysql.sql
@@ -20,7 +20,6 @@ CREATE TABLE IF NOT EXISTS allocation_ratios (
 -- Expenses table (with monthly tracking and custom allocation ratios)
 CREATE TABLE IF NOT EXISTS expenses (
   id VARCHAR(255) PRIMARY KEY,
-  category VARCHAR(255) NOT NULL,
   description TEXT NOT NULL,
   amount INT NOT NULL CHECK (amount > 0),
   payer_id VARCHAR(255) NOT NULL,

--- a/backend/src/services/expenseService-mysql.ts
+++ b/backend/src/services/expenseService-mysql.ts
@@ -24,16 +24,15 @@ export class ExpenseService {
       
       const sql = `
         INSERT INTO expenses (
-          id, category, description, amount, payer_id, expense_year, expense_month, 
+          id, description, amount, payer_id, expense_year, expense_month, 
           custom_husband_ratio, custom_wife_ratio, uses_custom_ratio, 
           created_at, updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `;
       
       await pool.execute(sql, [
         id, 
-        data.category, 
         data.description, 
         data.amount, 
         data.payerId, 
@@ -92,7 +91,6 @@ export class ExpenseService {
       
       const expenses: Expense[] = (rows as any[]).map((row: any) => ({
         id: row.id,
-        category: row.category,
         description: row.description,
         amount: row.amount,
         payerId: row.payer_id,
@@ -134,7 +132,6 @@ export class ExpenseService {
       
       const expenses: Expense[] = (rows as any[]).map((row: any) => ({
         id: row.id,
-        category: row.category,
         description: row.description,
         amount: row.amount,
         payerId: row.payer_id,
@@ -179,29 +176,13 @@ export class ExpenseService {
       const [basicRows] = await pool.execute(basicStatsSql, [year, month]);
       const basicStats = (basicRows as any[])[0];
       
-      // カテゴリ別統計を取得
-      const categorySql = `
-        SELECT category, SUM(amount) as amount
-        FROM expenses
-        WHERE expense_year = ? AND expense_month = ?
-        GROUP BY category
-      `;
-      
-      const [categoryRows] = await pool.execute(categorySql, [year, month]);
-      
-      const categories: { [category: string]: number } = {};
-      (categoryRows as any[]).forEach((row: any) => {
-        categories[row.category] = row.amount;
-      });
-      
       const summary: MonthlyExpenseSummary = {
         year,
         month,
         totalAmount: basicStats.total_amount || 0,
         totalExpenses: basicStats.total_expenses || 0,
         husbandAmount: basicStats.husband_amount || 0,
-        wifeAmount: basicStats.wife_amount || 0,
-        categories
+        wifeAmount: basicStats.wife_amount || 0
       };
       
       return {
@@ -311,7 +292,6 @@ export class ExpenseService {
       
       const expense: Expense = {
         id: row.id,
-        category: row.category,
         description: row.description,
         amount: row.amount,
         payerId: row.payer_id,

--- a/backend/src/services/settlementService-mysql.ts
+++ b/backend/src/services/settlementService-mysql.ts
@@ -8,7 +8,7 @@ export const settlementService = {
     try {
       // 費用を取得（個別配分比率を含む）
       const expenseQuery = `
-        SELECT id, category, description, amount, payer_id as payerId,
+        SELECT id, description, amount, payer_id as payerId,
                custom_husband_ratio as customHusbandRatio,
                custom_wife_ratio as customWifeRatio,
                uses_custom_ratio as usesCustomRatio,

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -8,7 +8,6 @@ export interface User {
 
 export interface Expense {
   id: string;
-  category: string;
   description: string;
   amount: number;
   payerId: string; // User ID
@@ -51,7 +50,6 @@ export interface Settlement {
 }
 
 export interface CreateExpenseRequest {
-  category: string;
   description: string;
   amount: number;
   payerId: string;
@@ -82,7 +80,6 @@ export interface MonthlyExpenseSummary {
   totalExpenses: number;
   husbandAmount: number;
   wifeAmount: number;
-  categories: { [category: string]: number };
 }
 
 export interface MonthlyExpenseRequest {

--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -11,18 +11,7 @@ export interface ExpenseFormHandle {
   resetAll: () => void;
 }
 
-const EXPENSE_CATEGORIES = [
-  '食費',
-  '日用品',
-  '交通費',
-  '光熱費',
-  '通信費',
-  '医療費',
-  '教育費',
-  '娯楽費',
-  '衣類費',
-  'その他'
-];
+
 
 const DEFAULT_USERS = [
   { id: 'husband-001', name: '夫', role: 'husband' as const },
@@ -66,7 +55,6 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
       if (stored) {
         const parsedData = JSON.parse(stored);
         return {
-          category: parsedData.category || '',
           description: parsedData.description || '',
           amount: 0, // 金額は常に0からスタート
           payerId: parsedData.payerId || 'husband-001',
@@ -80,7 +68,6 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
     
     // デフォルト値
     return {
-      category: '',
       description: '',
       amount: 0,
       payerId: 'husband-001',
@@ -95,7 +82,6 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
   const saveFormDataToStorage = (data: CreateExpenseRequest) => {
     try {
       const dataToStore = {
-        category: data.category,
         description: data.description,
         payerId: data.payerId,
         expenseYear: data.expenseYear,
@@ -117,7 +103,6 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
     },
     resetAll: () => {
       const clearedData = {
-        category: '',
         description: '',
         amount: 0,
         payerId: 'husband-001',
@@ -131,7 +116,7 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (formData.category && formData.description && formData.amount > 0) {
+    if (formData.description && formData.amount > 0) {
       onSubmit(formData);
       
       // Issue #14: 金額のみリセット、他のフィールドは保持
@@ -152,7 +137,6 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
 
   const handleClearForm = () => {
     const clearedData = {
-      category: '',
       description: '',
       amount: 0,
       payerId: 'husband-001',
@@ -208,26 +192,7 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
           </div>
         </div>
 
-        {/* カテゴリ選択 */}
-        <div>
-          <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-2">
-            カテゴリ *
-          </label>
-          <select
-            id="category"
-            value={formData.category}
-            onChange={(e) => handleInputChange('category', e.target.value)}
-            className="input-field"
-            required
-          >
-            <option value="">カテゴリを選択してください</option>
-            {EXPENSE_CATEGORIES.map(category => (
-              <option key={category} value={category}>
-                {category}
-              </option>
-            ))}
-          </select>
-        </div>
+
 
         {/* 説明入力 */}
         <div>
@@ -287,7 +252,7 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
         <div className="space-y-3">
           <button
             type="submit"
-            disabled={isLoading || !formData.category || !formData.description || formData.amount <= 0}
+            disabled={isLoading || !formData.description || formData.amount <= 0}
             className="btn-primary w-full disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isLoading ? '送信中...' : '入力完了'}

--- a/frontend/src/components/ExpenseList.tsx
+++ b/frontend/src/components/ExpenseList.tsx
@@ -422,11 +422,8 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({
                     </button>
                   </div>
 
-                  {/* 2行目：カテゴリ 年月 */}
+                  {/* 2行目：年月 */}
                   <div className="flex items-center gap-2">
-                    <span className="inline-block bg-primary-100 text-primary-800 text-xs px-2 py-1 rounded-full">
-                      {expense.category}
-                    </span>
                     <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
                       {formatMonthYear(expense.expenseYear, expense.expenseMonth)}
                     </span>

--- a/frontend/src/components/MonthlyExpenseStats.tsx
+++ b/frontend/src/components/MonthlyExpenseStats.tsx
@@ -169,35 +169,7 @@ export const MonthlyExpenseStats: React.FC<MonthlyExpenseStatsProps> = ({
         </div>
       </div>
 
-      {/* カテゴリ別（当月） */}
-      {Object.keys(currentMonth.categories).length > 0 && (
-        <div className="card">
-          <h3 className="text-xl font-bold mb-4 text-gray-800">
-            カテゴリ別支出（{formatMonthYear(currentMonth.year, currentMonth.month)}）
-          </h3>
-          <div className="space-y-3">
-            {Object.entries(currentMonth.categories)
-              .sort(([,a], [,b]) => b - a)
-              .map(([category, amount]) => {
-                const percentage = currentMonth.totalAmount > 0 
-                  ? Math.round((amount / currentMonth.totalAmount) * 100) 
-                  : 0;
-                
-                return (
-                  <div key={category} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                    <div className="flex items-center gap-3">
-                      <span className="font-medium text-gray-800">{category}</span>
-                      <span className="text-sm text-gray-500">({percentage}%)</span>
-                    </div>
-                    <span className="font-bold text-gray-900">
-                      ¥{formatAmount(amount)}
-                    </span>
-                  </div>
-                );
-              })}
-          </div>
-        </div>
-      )}
+
     </div>
   );
 }; 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,5 @@
 export interface Expense {
   id: string;
-  category: string;
   description: string;
   amount: number;
   payerId: string;
@@ -15,7 +14,6 @@ export interface Expense {
 }
 
 export interface CreateExpenseRequest {
-  category: string;
   description: string;
   amount: number;
   payerId: string;
@@ -92,7 +90,6 @@ export interface MonthlyExpenseSummary {
   totalExpenses: number;
   husbandAmount: number;
   wifeAmount: number;
-  categories: { [category: string]: number };
 }
 
 export interface MonthlyExpenseRequest {

--- a/scripts/remove-category-column.sql
+++ b/scripts/remove-category-column.sql
@@ -1,0 +1,19 @@
+-- 本番環境用: カテゴリカラム削除マイグレーション
+-- Issue #27: カテゴリ機能の削除
+
+-- 安全のためのバックアップ推奨
+-- mysqldump -u splitmate_user -p splitmate_database > backup_before_category_removal.sql
+
+-- expensesテーブルからcategoryカラムを削除
+ALTER TABLE expenses DROP COLUMN IF EXISTS category;
+
+-- 確認用クエリ
+SELECT 
+  COLUMN_NAME, 
+  DATA_TYPE, 
+  IS_NULLABLE, 
+  COLUMN_DEFAULT 
+FROM INFORMATION_SCHEMA.COLUMNS 
+WHERE TABLE_SCHEMA = 'splitmate' 
+  AND TABLE_NAME = 'expenses' 
+ORDER BY ORDINAL_POSITION; 


### PR DESCRIPTION
## 概要
Issue #27で要求されたカテゴリ機能の完全削除を実装しました。

## 背景
- カテゴリは夫婦間の精算に必要ない
- 精算時に必要なのは、相手にどんな支払いを行って立て替えたのか、だけ
- 説明で十分足りる

## 修正内容

### 🎨 **フロントエンド**
- **型定義**: `Expense`, `CreateExpenseRequest`, `MonthlyExpenseSummary`からcategoryフィールドを削除
- **ExpenseForm**: カテゴリ選択UIを完全削除、バリデーションも更新
- **ExpenseList**: カテゴリ表示バッジを削除
- **MonthlyExpenseStats**: カテゴリ別統計セクションを削除
- **LocalStorage**: 保存データからもcategoryフィールドを削除

### 🛠️ **バックエンド**
- **型定義**: `Expense`, `CreateExpenseRequest`, `MonthlyExpenseSummary`からcategoryフィールドを削除
- **コントローラー**: categoryバリデーションを削除
- **サービス層**: category関連のSQL処理とマッピングを削除
- **精算サービス**: category参照を削除

### 🗄️ **データベース**
- **スキーマ**: expensesテーブルからcategoryカラムを削除
- **マイグレーション**: 本番環境用のカラム削除スクリプトを作成(`scripts/remove-category-column.sql`)

## 破壊的変更
⚠️ **Breaking Changes**
- categoryフィールドが完全に削除されます
- カテゴリ別統計機能は利用できなくなります
- 既存データのcategoryカラムは本番環境で削除されます

## テスト結果
- ✅ フロントエンド・バックエンドビルド成功
- ✅ 開発環境でのデータベースマイグレーション成功
- ✅ API動作確認:
  - 費用作成: カテゴリなしで正常動作
  - 費用一覧: categoryフィールドなしで正常表示
  - 月次統計: categoriesフィールドなしで正常動作

## 本番環境デプロイ時の注意
1. 本番環境では`scripts/remove-category-column.sql`を実行してcategoryカラムを削除
2. データベースのバックアップを推奨
3. カテゴリ関連の既存UIやレポートが影響を受ける可能性

## 関連Issue
Fixes #27